### PR TITLE
Remove padding from ActorInit

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Addresses from:
     /* 0x13C */ char dbgPad[0x10]; // Padding that only exists in the debug rom
     #endif
     ```
-- z64actor.h, in `ActorInit`:
+- actor.h (not in include/ but at the repo's root), in `ActorInit`:
+    * replace `ActorInitExplPad` struct definition with `ActorInit`'s from `include/z64actor.h`
+    * rename that `ActorInit` copy to `ActorInitExplPad` and add the following padding member explicitly:
     ```
     /* 0x0A */ u16 padding; // Padding exists, but must be named for DEAD BEEF algorithm for zzrtl and friends
     ```

--- a/actor.h
+++ b/actor.h
@@ -1,10 +1,26 @@
 #ifndef _ACTOR_ADDITIONAL_H_
 #define _ACTOR_ADDITIONAL_H_
 
+#include "include/z64.h"
+
 #define ACTORFLAG_TARGET (1)
 #define ACTORFLAG_UNK_02 (1 << 2)
 #define ACTORFLAG_UNK_03 (1 << 3)
 #define ACTORFLAG_UPDATE (1 << 4) // Keeps updating no matter what
 #define ACTORFLAG_DRAW   (1 << 5) // Keeps drawing no matter what
+
+// The decomp's ActorInit struct with a padding member made explicit
+typedef struct {
+    /* 0x00 */ s16 id;
+    /* 0x02 */ u8 category; // Classifies actor and determines when it will update or draw
+    /* 0x04 */ u32 flags;
+    /* 0x08 */ s16 objectId;
+    /* 0x0A */ u16 padding; // Padding exists, but must be named for DEAD BEEF algorithm for zzrtl and friends
+    /* 0x0C */ u32 instanceSize;
+    /* 0x10 */ ActorFunc init; // Constructor
+    /* 0x14 */ ActorFunc destroy; // Destructor
+    /* 0x18 */ ActorFunc update; // Update Function
+    /* 0x1C */ ActorFunc draw; // Draw function
+} ActorInitExplPad; // size = 0x20
 
 #endif

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -31,7 +31,6 @@ typedef struct {
     /* 0x02 */ u8 category; // Classifies actor and determines when it will update or draw
     /* 0x04 */ u32 flags;
     /* 0x08 */ s16 objectId;
-    /* 0x0A */ u16 padding; // Padding exists, but must be named for DEAD BEEF algorithm for zzrtl and friends
     /* 0x0C */ u32 instanceSize;
     /* 0x10 */ ActorFunc init; // Constructor
     /* 0x14 */ ActorFunc destroy; // Destructor


### PR DESCRIPTION
And add ActorInitExplPad as alternative to ActorInit, same thing but Explicit Padding

Apparently modern tools don't need to use the magic values.
CAT detects the initvars and writes it to conf.txt for zzrtl if the initvars symbol is `init_vars` or `initvars`

[I didn't break the markdown](https://github.com/Dragorn421/z64hdr/blob/alternate_ActorInit/README.md#internal-documentation-what-to-change-when-copying-new-decomp-headers)